### PR TITLE
Add attribute examples and runner

### DIFF
--- a/examples/database/count_documents/main.go
+++ b/examples/database/count_documents/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/dm-vev/gowrite"
+	"github.com/joho/godotenv"
+)
+
+const (
+	dbID  = "example_database_id"
+	colID = "example_collection_id"
+)
+
+func main() {
+	if err := godotenv.Load(); err != nil {
+		log.Fatal("failed to load .env file:", err)
+	}
+
+	endpoint := os.Getenv("APPWRITE_INSTANCE")
+	project := os.Getenv("APPWRITE_PROJECT")
+	token := os.Getenv("APPWRITE_TOKEN")
+
+	if endpoint == "" || project == "" || token == "" {
+		log.Fatal("missing required environment variables: APPWRITE_INSTANCE, APPWRITE_PROJECT, APPWRITE_TOKEN")
+	}
+
+	client := gowrite.NewClient(endpoint, project, token)
+	databases := gowrite.NewDatabases(client)
+
+	count, err := databases.CountDocuments(dbID, colID, nil)
+	if err != nil {
+		log.Fatalf("failed to count documents: %v", err)
+	}
+
+	fmt.Printf("documents count: %d\n", count)
+}

--- a/examples/database/create_attribute/main.go
+++ b/examples/database/create_attribute/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/dm-vev/gowrite"
+	"github.com/joho/godotenv"
+)
+
+const (
+	dbID    = "example_database_id"
+	colID   = "example_collection_id"
+	attrKey = "example_attr"
+)
+
+func main() {
+	if err := godotenv.Load(); err != nil {
+		log.Fatal("failed to load .env file:", err)
+	}
+
+	endpoint := os.Getenv("APPWRITE_INSTANCE")
+	project := os.Getenv("APPWRITE_PROJECT")
+	token := os.Getenv("APPWRITE_TOKEN")
+
+	if endpoint == "" || project == "" || token == "" {
+		log.Fatal("missing required environment variables: APPWRITE_INSTANCE, APPWRITE_PROJECT, APPWRITE_TOKEN")
+	}
+
+	client := gowrite.NewClient(endpoint, project, token)
+	databases := gowrite.NewDatabases(client)
+
+	attr, err := databases.CreateStringAttribute(dbID, colID, attrKey, 255, false, "", false)
+	if err != nil {
+		log.Fatalf("failed to create attribute: %v", err)
+	}
+
+	fmt.Printf("created: %+v\n", attr)
+}

--- a/examples/database/create_collection/main.go
+++ b/examples/database/create_collection/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/dm-vev/gowrite"
+	"github.com/joho/godotenv"
+)
+
+const (
+	dbID    = "example_database_id"
+	colID   = "example_collection_id"
+	colName = "Example Collection"
+)
+
+func main() {
+	if err := godotenv.Load(); err != nil {
+		log.Fatal("failed to load .env file:", err)
+	}
+
+	endpoint := os.Getenv("APPWRITE_INSTANCE")
+	project := os.Getenv("APPWRITE_PROJECT")
+	token := os.Getenv("APPWRITE_TOKEN")
+
+	if endpoint == "" || project == "" || token == "" {
+		log.Fatal("missing required environment variables: APPWRITE_INSTANCE, APPWRITE_PROJECT, APPWRITE_TOKEN")
+	}
+
+	client := gowrite.NewClient(endpoint, project, token)
+	databases := gowrite.NewDatabases(client)
+
+	col, err := databases.CreateCollection(dbID, colID, colName, []string{gowrite.ReadAny, gowrite.WriteAny}, false, true)
+	if err != nil {
+		log.Fatalf("failed to create collection: %v", err)
+	}
+
+	fmt.Printf("created: %+v\n", col)
+}

--- a/examples/database/create_database/main.go
+++ b/examples/database/create_database/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/dm-vev/gowrite"
+	"github.com/joho/godotenv"
+)
+
+const (
+	dbID   = "example_database_id"
+	dbName = "Example Database"
+)
+
+func main() {
+	if err := godotenv.Load(); err != nil {
+		log.Fatal("failed to load .env file:", err)
+	}
+
+	endpoint := os.Getenv("APPWRITE_INSTANCE")
+	project := os.Getenv("APPWRITE_PROJECT")
+	token := os.Getenv("APPWRITE_TOKEN")
+
+	if endpoint == "" || project == "" || token == "" {
+		log.Fatal("missing required environment variables: APPWRITE_INSTANCE, APPWRITE_PROJECT, APPWRITE_TOKEN")
+	}
+
+	client := gowrite.NewClient(endpoint, project, token)
+	databases := gowrite.NewDatabases(client)
+
+	db, err := databases.CreateDatabase(dbID, dbName, true)
+	if err != nil {
+		log.Fatalf("failed to create database: %v", err)
+	}
+
+	fmt.Printf("created: %+v\n", db)
+}

--- a/examples/database/create_document/main.go
+++ b/examples/database/create_document/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/dm-vev/gowrite"
+	"github.com/joho/godotenv"
+)
+
+const (
+	dbID  = "example_database_id"
+	colID = "example_collection_id"
+	docID = "example_document_id"
+)
+
+func main() {
+	if err := godotenv.Load(); err != nil {
+		log.Fatal("failed to load .env file:", err)
+	}
+
+	endpoint := os.Getenv("APPWRITE_INSTANCE")
+	project := os.Getenv("APPWRITE_PROJECT")
+	token := os.Getenv("APPWRITE_TOKEN")
+
+	if endpoint == "" || project == "" || token == "" {
+		log.Fatal("missing required environment variables: APPWRITE_INSTANCE, APPWRITE_PROJECT, APPWRITE_TOKEN")
+	}
+
+	client := gowrite.NewClient(endpoint, project, token)
+	databases := gowrite.NewDatabases(client)
+
+	data := map[string]interface{}{"example": true}
+	doc, err := databases.CreateDocument(dbID, colID, docID, data, []string{gowrite.ReadAny, gowrite.WriteAny})
+	if err != nil {
+		log.Fatalf("failed to create document: %v", err)
+	}
+
+	fmt.Printf("created: %+v\n", doc)
+}

--- a/examples/database/delete_attribute/main.go
+++ b/examples/database/delete_attribute/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/dm-vev/gowrite"
+	"github.com/joho/godotenv"
+)
+
+const (
+	dbID    = "example_database_id"
+	colID   = "example_collection_id"
+	attrKey = "example_attr"
+)
+
+func main() {
+	if err := godotenv.Load(); err != nil {
+		log.Fatal("failed to load .env file:", err)
+	}
+
+	endpoint := os.Getenv("APPWRITE_INSTANCE")
+	project := os.Getenv("APPWRITE_PROJECT")
+	token := os.Getenv("APPWRITE_TOKEN")
+
+	if endpoint == "" || project == "" || token == "" {
+		log.Fatal("missing required environment variables: APPWRITE_INSTANCE, APPWRITE_PROJECT, APPWRITE_TOKEN")
+	}
+
+	client := gowrite.NewClient(endpoint, project, token)
+	databases := gowrite.NewDatabases(client)
+
+	if err := databases.DeleteAttribute(dbID, colID, attrKey); err != nil {
+		log.Fatalf("failed to delete attribute: %v", err)
+	}
+
+	fmt.Println("deleted attribute")
+}

--- a/examples/database/delete_collection/main.go
+++ b/examples/database/delete_collection/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/dm-vev/gowrite"
+	"github.com/joho/godotenv"
+)
+
+const (
+	dbID  = "example_database_id"
+	colID = "example_collection_id"
+)
+
+func main() {
+	if err := godotenv.Load(); err != nil {
+		log.Fatal("failed to load .env file:", err)
+	}
+
+	endpoint := os.Getenv("APPWRITE_INSTANCE")
+	project := os.Getenv("APPWRITE_PROJECT")
+	token := os.Getenv("APPWRITE_TOKEN")
+
+	if endpoint == "" || project == "" || token == "" {
+		log.Fatal("missing required environment variables: APPWRITE_INSTANCE, APPWRITE_PROJECT, APPWRITE_TOKEN")
+	}
+
+	client := gowrite.NewClient(endpoint, project, token)
+	databases := gowrite.NewDatabases(client)
+
+	if err := databases.DeleteCollection(dbID, colID); err != nil {
+		log.Fatalf("failed to delete collection: %v", err)
+	}
+
+	log.Println("collection deleted")
+}

--- a/examples/database/delete_database/main.go
+++ b/examples/database/delete_database/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/dm-vev/gowrite"
+	"github.com/joho/godotenv"
+)
+
+const dbID = "example_database_id"
+
+func main() {
+	if err := godotenv.Load(); err != nil {
+		log.Fatal("failed to load .env file:", err)
+	}
+
+	endpoint := os.Getenv("APPWRITE_INSTANCE")
+	project := os.Getenv("APPWRITE_PROJECT")
+	token := os.Getenv("APPWRITE_TOKEN")
+
+	if endpoint == "" || project == "" || token == "" {
+		log.Fatal("missing required environment variables: APPWRITE_INSTANCE, APPWRITE_PROJECT, APPWRITE_TOKEN")
+	}
+
+	client := gowrite.NewClient(endpoint, project, token)
+	databases := gowrite.NewDatabases(client)
+
+	if err := databases.DeleteDatabase(dbID); err != nil {
+		log.Fatalf("failed to delete database: %v", err)
+	}
+
+	log.Println("database deleted")
+}

--- a/examples/database/delete_document/main.go
+++ b/examples/database/delete_document/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/dm-vev/gowrite"
+	"github.com/joho/godotenv"
+)
+
+const (
+	dbID  = "example_database_id"
+	colID = "example_collection_id"
+	docID = "example_document_id"
+)
+
+func main() {
+	if err := godotenv.Load(); err != nil {
+		log.Fatal("failed to load .env file:", err)
+	}
+
+	endpoint := os.Getenv("APPWRITE_INSTANCE")
+	project := os.Getenv("APPWRITE_PROJECT")
+	token := os.Getenv("APPWRITE_TOKEN")
+
+	if endpoint == "" || project == "" || token == "" {
+		log.Fatal("missing required environment variables: APPWRITE_INSTANCE, APPWRITE_PROJECT, APPWRITE_TOKEN")
+	}
+
+	client := gowrite.NewClient(endpoint, project, token)
+	databases := gowrite.NewDatabases(client)
+
+	if err := databases.DeleteDocument(dbID, colID, docID); err != nil {
+		log.Fatalf("failed to delete document: %v", err)
+	}
+
+	log.Println("document deleted")
+}

--- a/examples/database/get_attribute/main.go
+++ b/examples/database/get_attribute/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/dm-vev/gowrite"
+	"github.com/joho/godotenv"
+)
+
+const (
+	dbID    = "example_database_id"
+	colID   = "example_collection_id"
+	attrKey = "example_attr"
+)
+
+func main() {
+	if err := godotenv.Load(); err != nil {
+		log.Fatal("failed to load .env file:", err)
+	}
+
+	endpoint := os.Getenv("APPWRITE_INSTANCE")
+	project := os.Getenv("APPWRITE_PROJECT")
+	token := os.Getenv("APPWRITE_TOKEN")
+
+	if endpoint == "" || project == "" || token == "" {
+		log.Fatal("missing required environment variables: APPWRITE_INSTANCE, APPWRITE_PROJECT, APPWRITE_TOKEN")
+	}
+
+	client := gowrite.NewClient(endpoint, project, token)
+	databases := gowrite.NewDatabases(client)
+
+	attr, err := databases.GetAttribute(dbID, colID, attrKey)
+	if err != nil {
+		log.Fatalf("failed to get attribute: %v", err)
+	}
+
+	fmt.Printf("retrieved: %+v\n", attr)
+}

--- a/examples/database/get_collection/main.go
+++ b/examples/database/get_collection/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/dm-vev/gowrite"
+	"github.com/joho/godotenv"
+)
+
+const (
+	dbID  = "example_database_id"
+	colID = "example_collection_id"
+)
+
+func main() {
+	if err := godotenv.Load(); err != nil {
+		log.Fatal("failed to load .env file:", err)
+	}
+
+	endpoint := os.Getenv("APPWRITE_INSTANCE")
+	project := os.Getenv("APPWRITE_PROJECT")
+	token := os.Getenv("APPWRITE_TOKEN")
+
+	if endpoint == "" || project == "" || token == "" {
+		log.Fatal("missing required environment variables: APPWRITE_INSTANCE, APPWRITE_PROJECT, APPWRITE_TOKEN")
+	}
+
+	client := gowrite.NewClient(endpoint, project, token)
+	databases := gowrite.NewDatabases(client)
+
+	col, err := databases.GetCollection(dbID, colID)
+	if err != nil {
+		log.Fatalf("failed to get collection: %v", err)
+	}
+
+	fmt.Printf("collection: %+v\n", col)
+}

--- a/examples/database/get_database/main.go
+++ b/examples/database/get_database/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/dm-vev/gowrite"
+	"github.com/joho/godotenv"
+)
+
+const dbID = "example_database_id"
+
+func main() {
+	if err := godotenv.Load(); err != nil {
+		log.Fatal("failed to load .env file:", err)
+	}
+
+	endpoint := os.Getenv("APPWRITE_INSTANCE")
+	project := os.Getenv("APPWRITE_PROJECT")
+	token := os.Getenv("APPWRITE_TOKEN")
+
+	if endpoint == "" || project == "" || token == "" {
+		log.Fatal("missing required environment variables: APPWRITE_INSTANCE, APPWRITE_PROJECT, APPWRITE_TOKEN")
+	}
+
+	client := gowrite.NewClient(endpoint, project, token)
+	databases := gowrite.NewDatabases(client)
+
+	db, err := databases.GetDatabase(dbID)
+	if err != nil {
+		log.Fatalf("failed to get database: %v", err)
+	}
+
+	fmt.Printf("database: %+v\n", db)
+}

--- a/examples/database/get_document/main.go
+++ b/examples/database/get_document/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/dm-vev/gowrite"
+	"github.com/joho/godotenv"
+)
+
+const (
+	dbID  = "example_database_id"
+	colID = "example_collection_id"
+	docID = "example_document_id"
+)
+
+func main() {
+	if err := godotenv.Load(); err != nil {
+		log.Fatal("failed to load .env file:", err)
+	}
+
+	endpoint := os.Getenv("APPWRITE_INSTANCE")
+	project := os.Getenv("APPWRITE_PROJECT")
+	token := os.Getenv("APPWRITE_TOKEN")
+
+	if endpoint == "" || project == "" || token == "" {
+		log.Fatal("missing required environment variables: APPWRITE_INSTANCE, APPWRITE_PROJECT, APPWRITE_TOKEN")
+	}
+
+	client := gowrite.NewClient(endpoint, project, token)
+	databases := gowrite.NewDatabases(client)
+
+	doc, err := databases.GetDocument(dbID, colID, docID)
+	if err != nil {
+		log.Fatalf("failed to get document: %v", err)
+	}
+
+	fmt.Printf("document: %+v\n", doc)
+}

--- a/examples/database/list_collections/main.go
+++ b/examples/database/list_collections/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/dm-vev/gowrite"
+	"github.com/joho/godotenv"
+)
+
+const dbID = "example_database_id"
+
+func main() {
+	if err := godotenv.Load(); err != nil {
+		log.Fatal("failed to load .env file:", err)
+	}
+
+	endpoint := os.Getenv("APPWRITE_INSTANCE")
+	project := os.Getenv("APPWRITE_PROJECT")
+	token := os.Getenv("APPWRITE_TOKEN")
+
+	if endpoint == "" || project == "" || token == "" {
+		log.Fatal("missing required environment variables: APPWRITE_INSTANCE, APPWRITE_PROJECT, APPWRITE_TOKEN")
+	}
+
+	client := gowrite.NewClient(endpoint, project, token)
+	databases := gowrite.NewDatabases(client)
+
+	cols, err := databases.ListCollections(dbID)
+	if err != nil {
+		log.Fatalf("failed to list collections: %v", err)
+	}
+
+	for i, c := range cols {
+		fmt.Printf("%d) %+v\n", i+1, c)
+	}
+}

--- a/examples/database/list_databases/main.go
+++ b/examples/database/list_databases/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/dm-vev/gowrite"
+	"github.com/joho/godotenv"
+)
+
+func main() {
+	if err := godotenv.Load(); err != nil {
+		log.Fatal("failed to load .env file:", err)
+	}
+
+	endpoint := os.Getenv("APPWRITE_INSTANCE")
+	project := os.Getenv("APPWRITE_PROJECT")
+	token := os.Getenv("APPWRITE_TOKEN")
+
+	if endpoint == "" || project == "" || token == "" {
+		log.Fatal("missing required environment variables: APPWRITE_INSTANCE, APPWRITE_PROJECT, APPWRITE_TOKEN")
+	}
+
+	client := gowrite.NewClient(endpoint, project, token)
+	databases := gowrite.NewDatabases(client)
+
+	dbs, err := databases.ListDatabases()
+	if err != nil {
+		log.Fatalf("failed to list databases: %v", err)
+	}
+
+	for i, db := range dbs {
+		fmt.Printf("%d) %+v\n", i+1, db)
+	}
+}

--- a/examples/database/list_documents/main.go
+++ b/examples/database/list_documents/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/dm-vev/gowrite"
+	"github.com/joho/godotenv"
+)
+
+const (
+	dbID  = "example_database_id"
+	colID = "example_collection_id"
+)
+
+func main() {
+	if err := godotenv.Load(); err != nil {
+		log.Fatal("failed to load .env file:", err)
+	}
+
+	endpoint := os.Getenv("APPWRITE_INSTANCE")
+	project := os.Getenv("APPWRITE_PROJECT")
+	token := os.Getenv("APPWRITE_TOKEN")
+
+	if endpoint == "" || project == "" || token == "" {
+		log.Fatal("missing required environment variables: APPWRITE_INSTANCE, APPWRITE_PROJECT, APPWRITE_TOKEN")
+	}
+
+	client := gowrite.NewClient(endpoint, project, token)
+	databases := gowrite.NewDatabases(client)
+
+	docs, err := databases.ListDocuments(dbID, colID, nil)
+	if err != nil {
+		log.Fatalf("failed to list documents: %v", err)
+	}
+
+	for i, d := range docs {
+		fmt.Printf("%d) %+v\n", i+1, d)
+	}
+}

--- a/examples/database/run_all.sh
+++ b/examples/database/run_all.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -e
+
+cd "$(dirname "$0")"
+
+if [ ! -f .env ]; then
+    echo "No .env file found in $(pwd)" >&2
+    exit 1
+fi
+
+# Execute each example
+examples=(
+    create_database
+    list_databases
+    get_database
+    update_database
+    delete_database
+    create_collection
+    list_collections
+    get_collection
+    update_collection
+    delete_collection
+    create_document
+    list_documents
+    get_document
+    update_document
+    delete_document
+    count_documents
+    create_attribute
+    get_attribute
+    delete_attribute
+)
+
+for ex in "${examples[@]}"; do
+    if [ -d "$ex" ]; then
+        echo "Running $ex..."
+        go run "./$ex" || exit 1
+        echo
+    fi
+done

--- a/examples/database/update_collection/main.go
+++ b/examples/database/update_collection/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/dm-vev/gowrite"
+	"github.com/joho/godotenv"
+)
+
+const (
+	dbID    = "example_database_id"
+	colID   = "example_collection_id"
+	colName = "Example Collection Updated"
+)
+
+func main() {
+	if err := godotenv.Load(); err != nil {
+		log.Fatal("failed to load .env file:", err)
+	}
+
+	endpoint := os.Getenv("APPWRITE_INSTANCE")
+	project := os.Getenv("APPWRITE_PROJECT")
+	token := os.Getenv("APPWRITE_TOKEN")
+
+	if endpoint == "" || project == "" || token == "" {
+		log.Fatal("missing required environment variables: APPWRITE_INSTANCE, APPWRITE_PROJECT, APPWRITE_TOKEN")
+	}
+
+	client := gowrite.NewClient(endpoint, project, token)
+	databases := gowrite.NewDatabases(client)
+
+	col, err := databases.UpdateCollection(dbID, colID, colName, []string{gowrite.ReadAny, gowrite.WriteAny}, false, true)
+	if err != nil {
+		log.Fatalf("failed to update collection: %v", err)
+	}
+
+	fmt.Printf("updated: %+v\n", col)
+}

--- a/examples/database/update_database/main.go
+++ b/examples/database/update_database/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/dm-vev/gowrite"
+	"github.com/joho/godotenv"
+)
+
+const (
+	dbID    = "example_database_id"
+	newName = "Example Database Updated"
+)
+
+func main() {
+	if err := godotenv.Load(); err != nil {
+		log.Fatal("failed to load .env file:", err)
+	}
+
+	endpoint := os.Getenv("APPWRITE_INSTANCE")
+	project := os.Getenv("APPWRITE_PROJECT")
+	token := os.Getenv("APPWRITE_TOKEN")
+
+	if endpoint == "" || project == "" || token == "" {
+		log.Fatal("missing required environment variables: APPWRITE_INSTANCE, APPWRITE_PROJECT, APPWRITE_TOKEN")
+	}
+
+	client := gowrite.NewClient(endpoint, project, token)
+	databases := gowrite.NewDatabases(client)
+
+	db, err := databases.UpdateDatabase(dbID, newName, true)
+	if err != nil {
+		log.Fatalf("failed to update database: %v", err)
+	}
+
+	fmt.Printf("updated: %+v\n", db)
+}

--- a/examples/database/update_document/main.go
+++ b/examples/database/update_document/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/dm-vev/gowrite"
+	"github.com/joho/godotenv"
+)
+
+const (
+	dbID  = "example_database_id"
+	colID = "example_collection_id"
+	docID = "example_document_id"
+)
+
+func main() {
+	if err := godotenv.Load(); err != nil {
+		log.Fatal("failed to load .env file:", err)
+	}
+
+	endpoint := os.Getenv("APPWRITE_INSTANCE")
+	project := os.Getenv("APPWRITE_PROJECT")
+	token := os.Getenv("APPWRITE_TOKEN")
+
+	if endpoint == "" || project == "" || token == "" {
+		log.Fatal("missing required environment variables: APPWRITE_INSTANCE, APPWRITE_PROJECT, APPWRITE_TOKEN")
+	}
+
+	client := gowrite.NewClient(endpoint, project, token)
+	databases := gowrite.NewDatabases(client)
+
+	data := map[string]interface{}{"updated": true}
+	doc, err := databases.UpdateDocument(dbID, colID, docID, data, []string{gowrite.ReadAny, gowrite.WriteAny})
+	if err != nil {
+		log.Fatalf("failed to update document: %v", err)
+	}
+
+	fmt.Printf("updated: %+v\n", doc)
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.8
 require github.com/json-iterator/go v1.1.12
 
 require (
+	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OHLH3mGKHDcjJRFFRrJa6eAM5H+CtDdOsPc=


### PR DESCRIPTION
## Summary
- implement basic attribute operations in `DatabaseService`
- create examples for creating, fetching and deleting attributes
- add `run_all.sh` script to execute every database example

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_684d496cb1348327944b280de0c76c68