### PR TITLE
Fix document creation by setting up schema

### DIFF
--- a/database_integration_test.go
+++ b/database_integration_test.go
@@ -84,6 +84,16 @@ func TestDatabaseIntegration(t *testing.T) {
 			}
 			log.Printf("Created collection - ID: %s Name: %s", col.ID, col.Name)
 
+			if _, err := db.CreateAttribute(dbID, colID, "num", gowrite.AttributeInteger, false, 0, false, map[string]interface{}{"min": 0, "max": 0}); err != nil {
+				t.Fatalf("CreateAttribute integer: %v", err)
+			}
+			if _, err := db.CreateAttribute(dbID, colID, "text", gowrite.AttributeString, false, "", false, map[string]interface{}{"size": 255}); err != nil {
+				t.Fatalf("CreateAttribute string: %v", err)
+			}
+			if _, err := db.CreateAttribute(dbID, colID, "flag", gowrite.AttributeBoolean, false, false, false, nil); err != nil {
+				t.Fatalf("CreateAttribute boolean: %v", err)
+			}
+
 			t.Cleanup(func(databaseID, collectionID string) func() {
 				return func() {
 					if err := db.DeleteCollection(databaseID, collectionID); err != nil {

--- a/examples/database/list_attributes/main.go
+++ b/examples/database/list_attributes/main.go
@@ -10,9 +10,8 @@ import (
 )
 
 const (
-	dbID    = "example_database_id"
-	colID   = "example_collection_id"
-	attrKey = "example_attr"
+	dbID  = "example_database_id"
+	colID = "example_collection_id"
 )
 
 func main() {
@@ -31,10 +30,12 @@ func main() {
 	client := gowrite.NewClient(endpoint, project, token)
 	databases := gowrite.NewDatabases(client)
 
-	attr, err := databases.CreateAttribute(dbID, colID, attrKey, gowrite.AttributeBoolean, false, false, false, nil)
+	attrs, err := databases.ListAttributes(dbID, colID, []string{})
 	if err != nil {
-		log.Fatalf("failed to create attribute: %v", err)
+		log.Fatalf("failed to list attributes: %v", err)
 	}
 
-	fmt.Printf("created: %+v\n", attr)
+	for _, a := range attrs {
+		fmt.Printf("attribute: %+v\n", a)
+	}
 }

--- a/examples/database/run_all.sh
+++ b/examples/database/run_all.sh
@@ -28,6 +28,8 @@ examples=(
     count_documents
     create_attribute
     get_attribute
+    update_attribute
+    list_attributes
     delete_attribute
 )
 

--- a/examples/database/update_attribute/main.go
+++ b/examples/database/update_attribute/main.go
@@ -31,10 +31,10 @@ func main() {
 	client := gowrite.NewClient(endpoint, project, token)
 	databases := gowrite.NewDatabases(client)
 
-	attr, err := databases.CreateAttribute(dbID, colID, attrKey, gowrite.AttributeBoolean, false, false, false, nil)
+	upd, err := databases.UpdateAttribute(dbID, colID, attrKey, gowrite.AttributeString, map[string]interface{}{"default": "new"})
 	if err != nil {
-		log.Fatalf("failed to create attribute: %v", err)
+		log.Fatalf("failed to update attribute: %v", err)
 	}
 
-	fmt.Printf("created: %+v\n", attr)
+	fmt.Printf("updated: %+v\n", upd)
 }


### PR DESCRIPTION
## Summary
- add universal `CreateAttribute` using an enum for all attribute types
- implement `ListAttributes` and `UpdateAttribute`
- extend integration test to check boolean attribute
- update example for boolean attribute
- add examples for listing and updating attributes

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684d68ea335883279cf6f19e0e7e7180